### PR TITLE
Cleanup openverso custom values file

### DIFF
--- a/napp/open5gs_values/5gSA_no_ues_values.yaml
+++ b/napp/open5gs_values/5gSA_no_ues_values.yaml
@@ -40,9 +40,6 @@ amf:
           - sst: 1
             sd: "0x111111"
 
-upf:
-  replicaCount: 3
-
 nssf:
   config:
     nsiList:

--- a/napp/open5gs_values/5gSA_no_ues_values_with_nodegroups.yaml
+++ b/napp/open5gs_values/5gSA_no_ues_values_with_nodegroups.yaml
@@ -60,19 +60,9 @@ udm:
 upf:
   replicaCount: 1
 
-# uncomment below line to select single node
+# uncomment below line to select a single node
 #  nodeSelector: {eks.amazonaws.com/nodegroup : upf-bedc-small}
 
-# uncomment below lines to add topology spread constraints for scheduling pods
-#  topologySpreadConstraints:
-#  - maxSkew: 1
-#    topologyKey: kubernetes.io/hostname
-#    whenUnsatisfiable: DoNotSchedule
-#    labelSelector:
-#      matchLabels:
-#        app.kubernetes.io/instance: open5gs
-#        app.kubernetes.io/name: upf
-#        helm.sh/chart: upf-2.0.6
   # affinity logic to deploy pods in multiple nodegroups
   affinity:
     nodeAffinity:
@@ -82,19 +72,16 @@ upf:
           - key: upfInstanceSize
             operator: In
             values:
-            - Large
-    # podAntiAffinity:
-    #   requiredDuringSchedulingIgnoredDuringExecution:
-    #     - labelSelector:
-    #         matchExpressions:
-    #           - key: app.kubernetes.io/name
-    #             operator: In
-    #             values:
-    #               - upf
-    #       topologyKey: kubernetes.io/hostname
-    #       namespaces:
-    #         - openverso
-
+            - Small
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - upf
+          topologyKey: kubernetes.io/hostname
 
 nssf:
   config:


### PR DESCRIPTION
File modified : 
- napp/open5gs_values/5gSA_no_ues_values_with_nodegroups.yaml 
-- updated default upf nodegroup to small, enable podAntiaffinity, removed node topology constraints (will add weights for selecting nodes in subsequent PR)

- napp/open5gs_values/5gSA_no_ues_values.yaml
-- reverted upf replica count change

